### PR TITLE
trigger handler thread safety (with tmp handlers)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in has-guarded-handlers.gemspec
 gemspec
+
+group :development do
+  gem 'listen', '~> 3.0.8', :require => false
+end

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -192,10 +192,10 @@ module HasGuardedHandlers
       # to make sure on re-try elements are not added
       # twice - attempt to copy _val_ to a new array:
       val = [].push *val
+      values.push *val # only here to ease testing
     rescue ConcurrencyError # re-read handler _val_
       return push_handler(handlers, key, values)
     end
-    values.push *val
   end
 
   def new_handler_id # :nodoc:

--- a/lib/has_guarded_handlers.rb
+++ b/lib/has_guarded_handlers.rb
@@ -193,7 +193,7 @@ module HasGuardedHandlers
       # twice - attempt to copy _val_ to a new array:
       val = [].push *val
       values.push *val # only here to ease testing
-    rescue ConcurrencyError # re-read handler _val_
+    rescue ThreadError # ConcurrencyError on JRuby
       return push_handler(handlers, key, values)
     end
   end

--- a/spec/has_guarded_handlers_spec.rb
+++ b/spec/has_guarded_handlers_spec.rb
@@ -80,6 +80,48 @@ describe HasGuardedHandlers do
       expect(subject.trigger_handler(:event, second_event)).to be true
       expect(subject.trigger_handler(:event, second_event)).to be false
     end
+
+    it 'recovers from concurrent modification as tmp handler is being removed' do
+      event = Object.new; def event.foo; :bar end
+      tmp_response = double '(tmp) Response'
+      expect(tmp_response).to receive(:call).exactly(1).times.with(event)
+      expect(response).to receive(:call).exactly(1).times.with(event)
+
+      require 'thread'; queue = Queue.new
+
+      subject.register_tmp_handler(:event, :foo => :bar) do |e|
+        tmp_response.call e; queue.pop
+      end
+
+      subject.register_handler(:event) do |e|
+         response.call e
+      end
+
+      Thread.new do
+        expect( subject.trigger_handler(:event, event) ).to be true
+      end
+
+      sleep 0.001 while queue.num_waiting == 0 # thread to end up in tmp handler
+
+      orig_method = subject.method(:push_handler)
+      subject.stub(:push_handler) do |handlers, key, values|
+        queue << :done; sleep 0.01 # let tmp handler finish-up
+        # we can not stub *val in any way thus we assume values.push
+        # is in the same begin - rescue block ...
+        def values.push(*args)
+          super.tap do
+            unless Thread.current[:__values_push_raised]
+              Thread.current[:__values_push_raised] = true
+              raise ConcurrencyError.new('stub-ed concurrent mod emulation')
+            end
+          end
+        end
+        orig_method.call(handlers, key, values)
+      end
+
+      expect( subject.trigger_handler(:event, event) ).to be true
+    end
+
   end
 
   it 'can unregister a handler after registration' do

--- a/spec/has_guarded_handlers_spec.rb
+++ b/spec/has_guarded_handlers_spec.rb
@@ -112,7 +112,8 @@ describe HasGuardedHandlers do
           super.tap do
             unless Thread.current[:__values_push_raised]
               Thread.current[:__values_push_raised] = true
-              raise ConcurrencyError.new('stub-ed concurrent mod emulation')
+              error = defined?(JRUBY_VERSION) ? ConcurrencyError : ThreadError
+              raise error.new('stub-ed concurrent mod emulation')
             end
           end
         end


### PR DESCRIPTION
in (rare) cases where HGH is used with concurrent thread access (e.g. `PB::Translator::Asterisk::Call`)
`trigger_handler` might fail with a `ConcurrencyError` (on JRuby) ... this is most evident with tmp handlers (but a concurrent handler removal is also the case).

JRuby tries to detect concurrent modification to Ruby structures such as `Array`, in this case the error is detected when `target.push *val`-ing an expanded array, the `val` array (holding the handler structure) gets modified before it's fully push-ed to target.

please note that in terms of thread-safety the current state of HGH under concurrent usage does not guarantee a tmp-handler to fire only once (for the target use-case `PB::Translator::Asterisk::Call` this seems to not impose any issues).
